### PR TITLE
Add `setStyle()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ if (ImGui.inputText('Text', input_text_buffer, 128)) {
 ```
 - The function `setIniFilename` doesn't exist in ImGui, it has been added to modify the filename of the default ini file saved by ImGui (pass null to turn off this feature).
 
+- Due to type conversions between Haxe and ImGui, editting the object returned from `getStyle` does not immediately update the default styles. The `setStyle` method has been added to provide that functionality. For example:
+```haxe
+var style:ImGuiStyle = ImGui.getStyle();
+style.WindowBorderSize = 0;
+style.WindowRounding = 0;
+ImGui.setStyle(style);
+```
+
 ## Bugs
 If you find bugs, please report them on the GitHub project page. Most of the binded functions have been tested, but as it's a new library some bugs might remain.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ if (ImGui.inputText('Text', input_text_buffer, 128)) {
 ```
 - The function `setIniFilename` doesn't exist in ImGui, it has been added to modify the filename of the default ini file saved by ImGui (pass null to turn off this feature).
 
-- Due to type conversions between Haxe and ImGui, editting the object returned from `getStyle` does not immediately update the default styles. The `setStyle` method has been added to provide that functionality. For example:
+- Due to type conversions between Haxe and ImGui, editing the object returned from `getStyle` does not immediately update the default styles. The `setStyle` method has been added to provide that functionality. For example:
 ```haxe
 var style:ImGuiStyle = ImGui.getStyle();
 style.WindowBorderSize = 0;

--- a/extension/hlimgui.cpp
+++ b/extension/hlimgui.cpp
@@ -188,6 +188,13 @@ HL_PRIM vdynamic* HL_NAME(get_style)()
 	return getHLFromImGuiStyle(ImGui::GetStyle());
 }
 
+HL_PRIM void HL_NAME(set_style)(vdynamic* hl_style)
+{
+	if (hl_style != nullptr) {
+		ImGui::GetStyle() = getImGuiStyleFromHL(hl_style);
+	}
+}
+
 HL_PRIM void HL_NAME(new_frame)()
 {
 	ImGui::NewFrame();
@@ -215,6 +222,7 @@ DEFINE_PRIM(_VOID, set_special_key_state, _BOOL _BOOL _BOOL);
 DEFINE_PRIM(_VOID, set_display_size, _I32 _I32);
 
 DEFINE_PRIM(_DYN, get_style, _NO_ARG);
+DEFINE_PRIM(_VOID, set_style, _DYN);
 DEFINE_PRIM(_VOID, new_frame, _NO_ARG);
 DEFINE_PRIM(_VOID, end_frame, _NO_ARG);
 DEFINE_PRIM(_VOID, render, _NO_ARG);

--- a/imgui/ImGui.hx
+++ b/imgui/ImGui.hx
@@ -505,6 +505,7 @@ class ImGui
 	
 	// Main
 	public static function getStyle() : ExtDynamic<ImGuiStyle> {return null;}
+	public static function setStyle(style : ExtDynamic<ImGuiStyle>) {}
 	public static function newFrame() {}
 	public static function endFrame() {}
 	public static function render() {}


### PR DESCRIPTION
When using ImGui normally, you can set the renderer's default styles by directly editing the object returned from `ImGui::GetStyle`. That doesn't work with this lib due to the conversion that takes place during the `getHLFromImGuiStyle` call in `getStyle`, so this PR adds a `setStyle` method that allows you to pass a style object and set the defaults. 

A small note + example for this was added to the README as well 👍 