### PR TITLE
Fix BeginMenu enabled default to match haxe binding

### DIFF
--- a/extension/widgets_menu.cpp
+++ b/extension/widgets_menu.cpp
@@ -26,7 +26,7 @@ HL_PRIM void HL_NAME(end_main_menu_bar)()
 
 HL_PRIM bool HL_NAME(begin_menu)(vstring* label, bool* enabled)
 {
-    return ImGui::BeginMenu(convertString(label), convertPtr(enabled, false));
+    return ImGui::BeginMenu(convertString(label), convertPtr(enabled, true));
 }
 
 HL_PRIM void HL_NAME(end_menu)()

--- a/extension/windows_utilities.cpp
+++ b/extension/windows_utilities.cpp
@@ -24,12 +24,12 @@ HL_PRIM bool HL_NAME(is_window_hovered)(ImGuiFocusedFlags* flags)
 	return ImGui::IsWindowHovered(convertPtr(flags, 0));
 }
 
-HL_PRIM bool HL_NAME(get_window_pos)()
+HL_PRIM vdynamic* HL_NAME(get_window_pos)()
 {
 	return getHLFromImVec2(ImGui::GetWindowPos());
 }
 
-HL_PRIM bool HL_NAME(get_window_size)()
+HL_PRIM vdynamic* HL_NAME(get_window_size)()
 {
 	return getHLFromImVec2(ImGui::GetWindowSize());
 }


### PR DESCRIPTION
Both the haxe binding and C++ header have enabled as the default behavior, this brings the actual behavior inline with the states and assumed behaviors.